### PR TITLE
Avoid negative countdown

### DIFF
--- a/models/stopwatch.js
+++ b/models/stopwatch.js
@@ -60,7 +60,9 @@ Stopwatch.prototype.reset = function() {
 };
 
 Stopwatch.prototype.onTick = function() {
-    this.time -= this.second;
+    if(this.time > 0) {
+        this.time -= this.second;
+    }
 
     var formattedTime = this.formatTime(this.time);
     this.emit('tick:stopwatch', formattedTime);


### PR DESCRIPTION
If the countdown is already at zero, don't decrement the time value. It
was previously causing negative numbers to be displayed on the
countdown clock (00:00:-4) if a start event was received after it had
reached zero.

Fixes #1 
