### PR TITLE
Updated stopwatch.js

### DIFF
--- a/models/stopwatch.js
+++ b/models/stopwatch.js
@@ -20,7 +20,7 @@ function Stopwatch() {
 
     // Use Underscore to bind all of our methods
     // to the proper context
-    _.bindAll(this);
+    _.bindAll(this, 'start', 'stop', 'reset', 'onTick', 'formatTime', 'getTime');
 };
 
 // ---------------------------------------------


### PR DESCRIPTION
Comment: http://robdodson.me/building-a-countdown-timer-with-socket-dot-io-pt-2/#comment-1289598915

Since Underscore.js 1.5.0, _.bindAll requires that you pass in the object and the names of the methods to bind on the object. In previous versions, like yours I'm guessing, there method names were optional.

_.bindAll(this, 'start', 'stop', 'reset', 'onTick', 'formatTime', 'getTime');
will fix this problem!
